### PR TITLE
Fix/frontend bug

### DIFF
--- a/apps/admin/messages/en.json
+++ b/apps/admin/messages/en.json
@@ -1004,6 +1004,7 @@
     "user": {
       "title": "User Growth",
       "chart": {
+        "today": "Today",
         "sugn_ups": "User Signups",
         "attendee": "Attendee",
         "organizer": "Organizer"

--- a/apps/admin/messages/fr.json
+++ b/apps/admin/messages/fr.json
@@ -993,6 +993,7 @@
     "user": {
       "title": "Croissance des utilisateurs",
       "chart": {
+        "today": "Auj.",
         "sugn_ups": "Inscriptions",
         "attendee": "Participant",
         "organizer": "Organisateur"

--- a/apps/admin/src/app/[locale]/analytics/RevenueGrowthChart.tsx
+++ b/apps/admin/src/app/[locale]/analytics/RevenueGrowthChart.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { Chart, registerables } from "chart.js";
+import { useTranslations } from "next-intl";
 
 Chart.register(...registerables);
 
@@ -10,6 +11,7 @@ type ChartPoint = { label: string; value: number };
 export default function RevenueGrowthChart({ data }: { data: ChartPoint[] }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
+  const intl = useTranslations("Analytics.user.chart");
 
   useEffect(() => {
     if (!canvasRef.current || data.length === 0) return;
@@ -17,8 +19,14 @@ export default function RevenueGrowthChart({ data }: { data: ChartPoint[] }) {
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
 
-    const labels = data.map((d, i) => (i === data.length - 1 ? "Today" : d.label));
-    const values = data.map((d) => d.value);
+    const today = new Date().getDate();
+
+    const filteredData = data.filter((item) => Number(item.label) <= today);
+    const labels = filteredData.map((d, i) =>
+      i === filteredData.length - 1 ? intl("today") : d.label,
+    );
+
+    const values = filteredData.map((d) => d.value);
 
     if (chartRef.current) {
       chartRef.current.destroy();
@@ -57,7 +65,7 @@ export default function RevenueGrowthChart({ data }: { data: ChartPoint[] }) {
             ticks: {
               maxTicksLimit: 31,
               color: (context) =>
-                context.tick.label === "Today" ? "#eb6819" : "#b5b5b5",
+                context.tick.label === intl("today") ? "#eb6819" : "#b5b5b5",
               font: { size: 11 },
             },
           },

--- a/apps/admin/src/app/[locale]/payments/PaymentsPageContent.tsx
+++ b/apps/admin/src/app/[locale]/payments/PaymentsPageContent.tsx
@@ -509,7 +509,7 @@ export default function PaymentsPageContent({
                   {t("transactions.no_results", { term: term.trim() })}
                 </p>
               ) : (
-                <div className="flex flex-col w-fit gap-12 items-center mt-8 self-center">
+                <div className="flex flex-col gap-12 items-center mt-8 self-center w-full">
                   <div className="rounded-full bg-neutral-100 p-6 w-fit">
                     <div className="flex items-center rounded-full bg-neutral-200 p-8 w-fit justify-center">
                       <Image

--- a/apps/attendee/src/app/[locale]/explore/ExplorePageContent.tsx
+++ b/apps/attendee/src/app/[locale]/explore/ExplorePageContent.tsx
@@ -190,9 +190,9 @@ export default function ExplorePageContent({
         </div>
       </motion.header>
       {hasAnyEvents ? (
-        <div className="pt-4 overflow-y-scroll flex flex-col gap-8">
+        <div className="pt-4 overflow-y-scroll flex flex-col gap-8 -mx-4">
           {filteredEvents.length > 0 && (
-            <ul className="list">
+            <ul className="list pt-4 px-4 pb-8 lg:pb-0">
               {filteredEvents.map((event, index) => (
                 <motion.li
                   key={event.eventId}
@@ -203,6 +203,7 @@ export default function ExplorePageContent({
                     ease: "easeOut",
                     delay: Math.min(index * 0.06, 0.3),
                   }}
+                  className="h-full flex"
                 >
                   <EventCard event={event} htgExchangeRate={htgExchangeRate} />
                 </motion.li>
@@ -211,33 +212,35 @@ export default function ExplorePageContent({
           )}
           {filteredRaffles.length > 0 && (
             <section className="flex flex-col gap-6">
-              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black">
+              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black lg:px-4">
                 {t("raffles")}
               </span>
-              <ul className="list">
-                {filteredRaffles.map((raffle, index) => (
-                  <motion.li
-                    key={raffle.raffleId}
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{
-                      duration: 0.35,
-                      ease: "easeOut",
-                      delay: Math.min(index * 0.06, 0.3),
-                    }}
-                  >
-                    <RaffleCard raffle={raffle} />
-                  </motion.li>
-                ))}
-              </ul>
+              <div className="-mx-4">
+                <ul className="list pt-4 px-4 pb-8 lg:pb-0">
+                  {filteredRaffles.map((raffle, index) => (
+                    <motion.li
+                      key={raffle.raffleId}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{
+                        duration: 0.35,
+                        ease: "easeOut",
+                        delay: Math.min(index * 0.06, 0.3),
+                      }}
+                    >
+                      <RaffleCard raffle={raffle} />
+                    </motion.li>
+                  ))}
+                </ul>
+              </div>
             </section>
           )}
           {filteredRestaurants.length > 0 && (
             <section className="flex flex-col gap-6">
-              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black">
+              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black px-4">
                 {t("restaurants")}
               </span>
-              <ul className="list">
+              <ul className="list pt-4 px-4 pb-8 lg:pb-0">
                 {filteredRestaurants.map((restaurant, index) => (
                   <motion.li
                     key={restaurant.restaurantId}
@@ -257,10 +260,10 @@ export default function ExplorePageContent({
           )}
           {filteredPastEvents.length > 0 && (
             <section className="flex flex-col gap-6">
-              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black">
+              <span className="font-primary font-medium text-[1.8rem] lg:text-[2.2rem] leading-8 text-black px-4">
                 {t("pastActivities")}
               </span>
-              <ul className="list opacity-70">
+              <ul className="list opacity-70 pt-4 px-4 pb-8 lg:pb-0">
                 {filteredPastEvents.map((event, index) => (
                   <motion.li
                     key={event.eventId}

--- a/apps/attendee/src/app/[locale]/history/page.tsx
+++ b/apps/attendee/src/app/[locale]/history/page.tsx
@@ -82,8 +82,8 @@ export default async function HistoryPage() {
 
         {/* main */}
         {events.length > 0 ? (
-          <div className="pt-4 overflow-y-scroll flex flex-col gap-8">
-            <ul className="list">
+          <div className="pt-4 overflow-y-scroll flex flex-col gap-8 -mx-4">
+            <ul className="list px-4 pb-8 ">
               {events.map((event) => (
                 <li key={event.eventId}>
                   <HistoryCard

--- a/apps/attendee/src/app/[locale]/organisations/OrganizerCard.tsx
+++ b/apps/attendee/src/app/[locale]/organisations/OrganizerCard.tsx
@@ -28,43 +28,43 @@ function OrganizerCard({
     <Link
       href={`/organisations/${slugify(title, id)}`}
       className={
-        "flex items-stretch flex-col gap-4 w-full lg:max-w-[350px] bg-white shadow-lg rounded-[1rem] overflow-hidden pb-4"
+        "flex items-stretch flex-col gap-4 w-full lg:max-w-140 bg-white shadow-lg rounded-[10px] overflow-hidden pb-4"
       }
     >
       {image ? (
         <Image
           src={image}
-          className={"h-[150px] w-full object-cover"}
+          className={"h-60 w-full object-cover"}
           alt={title}
           height={150}
           width={255}
         />
       ) : (
-        <div className="h-[150px] w-full flex items-center justify-center bg-black text-white text-9xl font-primary">
+        <div className="h-60 w-full flex items-center justify-center bg-black text-white text-9xl font-primary">
           {title.slice()[0]?.toUpperCase()}
         </div>
       )}
-      <div className={"px-4 flex flex-col gap-[1.5rem] lg:gap-4"}>
+      <div className={"px-4 flex flex-col gap-6 lg:gap-4"}>
         <span
-          className={"font-semibold text-[1.2rem] text-deep-100 leading-[17px]"}
+          className={"font-semibold text-[1.2rem] text-deep-100 leading-[1.7rem]"}
         >
           {title} {isVerified && <VerifiedOrganisationCheckMark />}
         </span>
         <div className={"flex items-center justify-between"}>
-          <div className={"flex items-center gap-[5px]"}>
+          <div className={"flex items-center gap-2"}>
             <Layer size="15" color="#2e3237" variant="Bulk" />
             <p
               className={
-                "font-normal text-[1rem] leading-[15px] text-neutral-700"
+                "font-normal text-[1rem] leading-6 text-neutral-700"
               }
             >
               <span className={"text-deep-100"}>{number}</span> {t("event")}
             </p>
           </div>
-          <div className={"flex items-center gap-[5px]"}>
+          <div className={"flex items-center gap-2"}>
             <Location size="15" color="#2e3237" variant="Bulk" />
             <p
-              className={"font-medium text-[1rem] text-deep-100 leading-[15px]"}
+              className={"font-medium text-[1rem] text-deep-100 leading-6"}
             >
               {city}, <span className={"text-neutral-700"}>{country}</span>
             </p>

--- a/apps/attendee/src/app/[locale]/organisations/OrganizersContents.tsx
+++ b/apps/attendee/src/app/[locale]/organisations/OrganizersContents.tsx
@@ -272,8 +272,8 @@ export default function OrganizersContents({
           <TabsTrigger value="following">{t("filters.following")}</TabsTrigger>
           {/* <TabsTrigger value="popular">{t('filters.popular')}</TabsTrigger> */}
         </TabsList>
-        <TabsContent value="all" className="min-h-0 overflow-y-scroll">
-          <ul className="list pt-4">
+        <TabsContent value="all" className="min-h-0 overflow-y-scroll -mx-4">
+          <ul className="list pt-4 px-4 pb-8 lg:pb-0">
             {filteredOrganisations.map((organisation) => {
               const events = organisation.events.length;
               return (
@@ -305,10 +305,10 @@ export default function OrganizersContents({
             </div>
           )}
         </TabsContent>
-        <TabsContent value="following">
+        <TabsContent value="following" className="min-h-0 overflow-y-scroll -mx-4">
           {followedOrganisations.length > 0 ? (
             <>
-              <ul className="list pt-4">
+              <ul className="list pt-4 px-4 pb-8 lg:pb-0">
                 {filteredFollowedOrganisations.map((organisation) => {
                   const events = organisation.events.length;
                   return (

--- a/apps/attendee/src/app/[locale]/upcoming/UpcomingPageContent.tsx
+++ b/apps/attendee/src/app/[locale]/upcoming/UpcomingPageContent.tsx
@@ -92,31 +92,33 @@ export default function UpcomingPageContent({ events }: { events: any }) {
         </div>
       </motion.header>
       <>
-        <ul className="list pt-4 overflow-y-scroll">
-          {filteredEvents.map((event: any, index) => {
-            const slug = slugify(event.eventName, event.eventId);
-            return (
-              <motion.li
-                key={event.eventId}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{
-                  duration: 0.35,
-                  ease: "easeOut",
-                  delay: Math.min(index * 0.06, 0.3),
-                }}
-              >
-                <UpcomingCard
-                  href={`upcoming/${slug}`}
-                  image={event.eventImageUrl}
-                  name={event.eventName}
-                  eventDays={event.eventDays ?? []}
-                  tickets={event.tickets?.length ?? 0}
-                />
-              </motion.li>
-            );
-          })}
-        </ul>
+        <div className="pt-4 overflow-y-scroll flex flex-col gap-8 -mx-4">
+          <ul className="list px-4 pb-8">
+            {filteredEvents.map((event: any, index) => {
+              const slug = slugify(event.eventName, event.eventId);
+              return (
+                <motion.li
+                  key={event.eventId}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: 0.35,
+                    ease: "easeOut",
+                    delay: Math.min(index * 0.06, 0.3),
+                  }}
+                >
+                  <UpcomingCard
+                    href={`upcoming/${slug}`}
+                    image={event.eventImageUrl}
+                    name={event.eventName}
+                    eventDays={event.eventDays ?? []}
+                    tickets={event.tickets?.length ?? 0}
+                  />
+                </motion.li>
+              );
+            })}
+          </ul>
+        </div>
         <AnimatePresence>
           {list.length > 0 && filteredEvents.length === 0 && (
             <motion.div

--- a/apps/attendee/src/components/HistoryCard.tsx
+++ b/apps/attendee/src/components/HistoryCard.tsx
@@ -22,7 +22,7 @@ function HistoryCard({
   return (
     <Link
       href={href}
-      className={`flex flex-col  lg:items-stretch  gap-4 w-full mb-8 lg:ml-4 bg-white shadow-lg rounded-[10px] overflow-hidden pb-4  hover:shadow-xl`}
+      className={`flex flex-col  lg:items-stretch  gap-4 w-full mb-8 bg-white shadow-lg rounded-[10px] overflow-hidden pb-4  hover:shadow-xl`}
     >
       <Image
         src={image}

--- a/apps/attendee/src/components/UpcomingCard.tsx
+++ b/apps/attendee/src/components/UpcomingCard.tsx
@@ -96,7 +96,7 @@ function UpcomingCard({
   return (
     <Link
       href={href}
-      className={`flex flex-row items-center lg:items-stretch lg:mb-8 lg:ml-4 lg:flex-col gap-4 w-full bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl`}
+      className={`flex flex-row items-center lg:items-stretch lg:mb-8 lg:flex-col gap-4 w-full bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl`}
     >
       <div className="relative">
         <Image

--- a/apps/attendee/src/components/shared/EventCard.tsx
+++ b/apps/attendee/src/components/shared/EventCard.tsx
@@ -42,7 +42,7 @@ function EventCard({
   return (
     <Link
       href={`/explore/${slug}`}
-      className={`flex flex-row items-center lg:items-stretch lg:mb-8 lg:ml-4 lg:flex-col gap-4 w-full ${!aside && "lg:max-w-140"} bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl`}
+      className={`flex flex-row items-center lg:items-stretch lg:mb-8 lg:flex-col gap-4 w-full ${!aside && "lg:max-w-140"} bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl`}
     >
       <div className="relative">
         <Image

--- a/apps/attendee/src/components/shared/RestaurantCard.tsx
+++ b/apps/attendee/src/components/shared/RestaurantCard.tsx
@@ -25,7 +25,7 @@ function RestaurantCard({ restaurant }: { restaurant: Restaurant }) {
   return (
     <Link
       href={`/explore/restaurant/${restaurant.slug}`}
-      className="flex flex-row items-center lg:items-stretch lg:mb-8 lg:ml-4 lg:flex-col gap-4 w-full lg:max-w-140 bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0">
+      className="flex flex-row items-center lg:items-stretch lg:mb-8 lg:flex-col gap-4 w-full lg:max-w-140 bg-white shadow-lg rounded-[10px] overflow-hidden pb-4 pl-4 lg:pl-0">
       <div className="relative">
         {restaurant.coverImageUrl && (
           <Image

--- a/apps/organisation/messages/fr.json
+++ b/apps/organisation/messages/fr.json
@@ -393,7 +393,7 @@
       "classes": "Distribution des classes de billets",
       "daily": "Ventes de billets quotidiennes",
       "daily_chart": {
-        "today": "Aujourd'hui",
+        "today": "Auj.",
         "mon": "Lun",
         "tue": "Mar",
         "wed": "Mer",

--- a/apps/organisation/src/app/[locale]/analytics/DailyTicketSalesChart.tsx
+++ b/apps/organisation/src/app/[locale]/analytics/DailyTicketSalesChart.tsx
@@ -28,7 +28,7 @@ function processTicketsDataByDay(
   for (let i = 7; i >= 0; i--) {
     const d = new Date(today);
     d.setDate(d.getDate() - i);
-    const key = d.toISOString().slice(0, 10); // "YYYY-MM-DD"
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
     counts[key] = 0;
   }
 


### PR DESCRIPTION
## Summary

### Fixes

* Aligned card heights in the **Explore** page to ensure all cards have consistent dimensions.
* Updated card shadow styles across all pages containing cards to better match the Figma design.
* Centered the **No History** empty state display on the Payment page.
* Fixed the extra day issue in the **Revenue Growth** chart.
* Shortened the French "Aujourd'hui" label to "Auj." to prevent design overflow and preserve layout consistency.
